### PR TITLE
Caching facility

### DIFF
--- a/waveform.el
+++ b/waveform.el
@@ -62,6 +62,13 @@ should return a string to include in the filter.  See
           (function :tag "Function to call with the width and height"))
   :group 'waveform)
 
+(defcustom waveform-save-cache nil
+  "When non-nil, cache waveforms in `waveform-cache-directory'.")
+
+(defcustom waveform-cache-directory (concat user-emacs-directory
+                                            (file-name-as-directory "waveforms"))
+  "Directory to use for caching waveforms.")
+
 (defun waveform-fancy-filter (width height)
   "Displays green waveforms on a dark green background with a grid.
 WIDTH and HEIGHT are given in pixels."
@@ -250,6 +257,20 @@ of \\[universal-argument] will add another `mpv-seek-step' seconds."
   (interactive)
   (kill-buffer)
   (mpv-kill))
+
+(defun waveform-cache-p (file)
+  "Return t if FILE has already been cached.")
+
+(defun waveform-cache-actual-p (file)
+  "Return t if the cache of FILE is actual.
+A cache is considered actual if the hash of FILE corresponds the
+one stored by waveform.el."
+  (waveform-cache-p file))
+
+(defun waveform-cache-read (file)
+  "Read")
+
+(defun waveform-cache)
 
 (defvar-local waveform-mark-msecs nil)
 (defvar-local waveform--position-indicator nil)


### PR DESCRIPTION
The time that `ffmpeg` takes to generate waveforms is ratioed by the length of the video and the processing capabilities of the system.  As such it'd be good to only have the system generate those waveforms once for a given file and cache it.  However, since we adapt the dimensions of the waveforms by window height & width, this is not practical.

### Potential solution
Cache a precise-enough waveform, and resize it for windows demand.  We should be able to keep enough information during the resize.

### Extra thoughts
- We can only apply this caching for files above a certain size/length.
- If the resizing loses too much information, we have generate 3-4 images which would be within the ballpark of most desired window height & width, and use the closest image for resize.